### PR TITLE
3 - improve css validation

### DIFF
--- a/src/utils/filter-styles.js
+++ b/src/utils/filter-styles.js
@@ -2,8 +2,69 @@
 
 import { StyleSheet } from "react-native";
 
+const isNumber = value => Number.isFinite(value);
+const isString = value => Number.isNaN(value);
+
 const validateStyles = {
-  fontSize: [value => Number.isFinite(value)]
+  // VIEW - styles
+  backfaceVisibility: [value => ["visible", "hidden"].includes(value)],
+  borderColor: [isString],
+  borderTopColor: [isString],
+  borderRightColor: [isString],
+  borderBottomColor: [isString],
+  borderLeftColor: [isString],
+  borderWidth: [isNumber],
+  borderTopWidth: [isNumber],
+  borderRightWidth: [isNumber],
+  borderBottomWidth: [isNumber],
+  borderLeftWidth: [isNumber],
+  borderRadius: [isNumber],
+  borderStyle: [value => ["solid", "dotted", "dashed"].includes(value)],
+  // TEXT - styles
+  // fontFamily - can't prevent crash, since fonts are loaded dynamically
+  fontSize: [isNumber],
+  fontStyle: [value => ["normal", "italic"].includes(value)],
+  fontVariant: [
+    value =>
+      [
+        "small-caps",
+        "oldstyle-nums",
+        "lining-nums",
+        "tabular-nums",
+        "proportional-nums"
+      ].includes(value)
+  ],
+  fontWeight: [
+    value =>
+      [
+        "normal",
+        "bold",
+        "100",
+        "200",
+        "300",
+        "400",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900"
+      ].includes(value)
+  ],
+  letterSpacing: [isNumber],
+  lineHeight: [isNumber],
+  opacity: [isNumber],
+  textAlign: [
+    value => ["auto", "left", "right", "center", "justify"].includes(value)
+  ],
+  textDecorationLine: [
+    value =>
+      ["none", "underline", "line-through", "underline line-through"].includes(
+        value
+      )
+  ],
+  textDecorationStyle: [
+    value => ["solid", "double", "dotted", "dashed"].includes(value)
+  ]
 };
 
 const isValidStyle = (style, value) => {


### PR DESCRIPTION
## Description
Fix #3 
allow only supported react-native stylesheet values.

## Example
If we pass: `text-align: start`, it will get through validation, but it will fail to render, since RN does not support `start`.